### PR TITLE
feat: use default branch instead of hardcoded master

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,3 +20,5 @@ jobs:
 
     - name: Build
       run: make ci
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Build
         run: make ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -2,7 +2,6 @@ package main_test
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -67,10 +66,75 @@ func TestReviewdogE2E(t *testing.T) {
 	}
 
 	version := stdout.String()
-	fmt.Printf("Installed reviewdog version: %s\n", version)
 	if version == "" {
 		t.Fatal("reviewdog -version returned empty output")
 	}
 
 	t.Logf("Successfully installed and ran reviewdog version: %s", version)
+}
+
+// TestGoreleaserE2E tests that the goinstaller tool can generate a working
+// installation script for the goreleaser repository, which uses "main"
+// as its default branch, and that the script can successfully install
+// the goreleaser binary.
+func TestGoreleaserE2E(t *testing.T) {
+	// Create a temporary directory for all test artifacts
+	tempDir := t.TempDir()
+
+	// Build the goinstaller tool to a temporary location
+	goinstallerPath := filepath.Join(tempDir, "goinstaller")
+	cmd := exec.Command("go", "build", "-o", goinstallerPath)
+	cmd.Dir = ".." // Go up one level to reach the root directory
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to build goinstaller: %v", err)
+	}
+
+	// Generate the installation script for goreleaser
+	installerPath := filepath.Join(tempDir, "goreleaser-install.sh")
+	cmd = exec.Command(goinstallerPath, "--repo=goreleaser/goreleaser")
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to generate installation script: %v", err)
+	}
+
+	// Write the installation script to a file
+	if err := os.WriteFile(installerPath, stdout.Bytes(), 0755); err != nil {
+		t.Fatalf("Failed to write installation script: %v", err)
+	}
+
+	// Create a temporary bin directory
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("Failed to create bin directory: %v", err)
+	}
+
+	// Run the installation script
+	cmd = exec.Command("sh", installerPath, "-b", binDir)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to run installation script: %v\nStderr: %s", err, stderr.String())
+	}
+
+	// Check that the goreleaser binary was installed
+	goreleaserPath := filepath.Join(binDir, "goreleaser")
+	if _, err := os.Stat(goreleaserPath); os.IsNotExist(err) {
+		t.Fatalf("goreleaser binary was not installed at %s", goreleaserPath)
+	}
+
+	// Check that the goreleaser binary works
+	cmd = exec.Command(goreleaserPath, "--version")
+	stdout.Reset()
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to run goreleaser --version: %v", err)
+	}
+
+	version := stdout.String()
+	if version == "" {
+		t.Fatal("goreleaser --version returned empty output")
+	}
+
+	t.Logf("Successfully installed and ran goreleaser version: %s", version)
 }

--- a/shellfn.go
+++ b/shellfn.go
@@ -215,7 +215,7 @@ hash_sha256_verify() {
     return 1
   fi
   BASENAME=${TARGET##*/}
-  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  want=$(grep -E "(^|[[:space:]])${BASENAME}([[:space:]]|$)" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
   if [ -z "$want" ]; then
     log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
     return 1


### PR DESCRIPTION
This PR modifies the code to use the default branch of a repository instead of hardcoding 'master'. It also adds support for using the GITHUB_TOKEN environment variable to avoid rate limiting when making API requests to GitHub.